### PR TITLE
Fix and refactor `loadDiffIntoAuditor`

### DIFF
--- a/src/Audit/Generate.hs
+++ b/src/Audit/Generate.hs
@@ -13,11 +13,13 @@ import           Data.Hashable              (hash)
 import           Data.Text                  (unpack)
 import           System.Directory           (getDirectoryContents)
 import           System.Process             (callCommand)
+import           Control.Monad.Trans.Either (runEitherT)
 
 import           Audit.Operations           (buildPackageList, checkHash,
                                              clearDiffTable, deleteHash,
                                              insertAuditorDeps, insertHash,
-                                             loadDiffIntoAuditor,
+                                             loadDiffIntoAuditorNew,
+                                             loadDiffIntoAuditorUpdate,
                                              loadDiffTableRemovedDeps,
                                              loadNewDirDepsDiff,
                                              loadNewIndirectDepsDiff)
@@ -138,7 +140,8 @@ update = do
         _ -> do
                   print "Inserting changes from Diff table into \
                         \Auditor table.."
-                  loadDiffIntoAuditor "auditor.db"
+                  _ <- runEitherT $ loadDiffIntoAuditorNew "auditor.db"
+                  _ <- runEitherT $ loadDiffIntoAuditorUpdate "auditor.db"
                   print "Overwriting original repository dependency \
                         \tree & clearing Diff table"
                   callCommand "stack dot --external > repoinfo/currentDepTree.dot"

--- a/src/Audit/Types.hs
+++ b/src/Audit/Types.hs
@@ -29,7 +29,10 @@ data AnalysisStatus
 
 newtype Command = Command String
 
-data ConversionError = UTCTimeParseError String deriving Show
+data ConversionError =
+     UTCTimeParseError String
+  |  DiffToAuditorError Text
+  deriving Show
 
 type DirectDependency = String
 
@@ -46,6 +49,7 @@ type IndirectDependency = String
 data OperationError =
    OnlyDirectDepenciesAllowed [Package]
  | OnlyIndirectDepenciesAllowed [Package]
+ | ConvError ConversionError
  deriving Show
 
 data OperationResult =
@@ -53,6 +57,12 @@ data OperationResult =
     -- ^ Already added dependencies to the Diff table.
   | AddedDependenciesDiff
     -- ^ Successfully added dependencies to the Diff table.
+  | NoDependenciesRemoved
+    -- ^ No dependencies have been removed.
+  | AddedRemovedDependenciesDiff
+    -- ^ Successfully added removed dependencies to the Diff table.
+  | AddedRemovedDependenciesAuditor
+    -- ^ Successfully added removed dependencies to the Auditor table.
   deriving Show
 
 data Package = Package

--- a/test/Test/Audit/Gen.hs
+++ b/test/Test/Audit/Gen.hs
@@ -24,7 +24,6 @@ import qualified Data.Text
 import           Data.Time.Calendar     (Day (..))
 import           Data.Time.Clock        (DiffTime (..), UTCTime (..),
                                          getCurrentTime, secondsToDiffTime)
-
 import           Control.Monad.IO.Class (liftIO)
 import           Hedgehog
 import qualified Hedgehog.Gen           as Gen


### PR DESCRIPTION
Basically separates `loadDiffIntoAuditor` into two functions  `loadDiffIntoAuditorNew` and  `loadDiffIntoAuditorUpdate`.
- `loadDiffIntoAuditorNew`: responsible for updating the `Auditor` table with new dependencies from the `Diff` table. 
- `loadDiffIntoAuditorUpdate`: responsible for updating the `Auditor` table with changes to existing dependencies via the `Diff` table. 